### PR TITLE
Andrew/openrouter

### DIFF
--- a/constants/cli.py
+++ b/constants/cli.py
@@ -1,3 +1,10 @@
+OPENAI_MODELS = [
+    "gpt-4-1106-preview",
+    "gpt-4",
+    "gpt-3.5-turbo",
+    "gpt-3.5-turbo-16k",
+]
+
 ARGUMENTS = [
     {
         "name": "k_value",
@@ -17,13 +24,7 @@ ARGUMENTS = [
         "nickname": "m",
         "help_text": "Specify the model. Default: gpt-4",
         "type": str,
-        "default": "gpt-4",
-        "choices": [
-            "gpt-4-1106-preview",
-            "gpt-4",
-            "gpt-3.5-turbo",
-            "gpt-3.5-turbo-16k",
-        ],
+        "default": "gpt-4"
     },
     {
         "name": "cite_sources",

--- a/constants/cli.py
+++ b/constants/cli.py
@@ -37,7 +37,7 @@ ARGUMENTS = [
         "nickname": "n",
         "help_text": "Uses LMStudio for local models",
         "type": bool,
-        "default": True,
+        "default": False,
     },
     {
         "name": "context_window",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fleet-context"
-version = "1.0.16"
+version = "1.0.17"
 description = "A chat interface over up-to-date Python library documentation."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="fleet-context",
-    version="1.0.16",
+    version="1.0.17",
     description="A chat interface over up-to-date Python library documentation.",
     long_description=open("README.md", "r", encoding="utf8").read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Made a few changes:

1. Calling `openai.chatCompletion.create()` no longer works, and `openai.chat.completions.create()` is not compatible with OpenRouter, so I changed it to curl the URL
2. We'll only ask for OpenRouter API keys if the user asks to use a non-OpenAI model

LMK what you think!